### PR TITLE
Updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The classic memory game, with your favorite hubbers
 
-![](http://i.imgur.com/KLl5oEO.jpg)
+[![](http://i.imgur.com/KLl5oEO.jpg)](http://alysonla.github.io/hubber-memory-game/)
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The classic memory game, with your favorite hubbers
 
-[![](http://i.imgur.com/KLl5oEO.jpg)](http://alysonla.github.io/hubber-memory-game/)
+[![](http://i.imgur.com/KLl5oEO.jpg)](https://alysonla.github.io/hubber-memory-game/)
 
 ## Resources
 
@@ -26,7 +26,7 @@ Just open the index.html file in a browser. No frameworks needed. :grin:
 The [`js/Hubbers.js`](/js/Hubbers.js) file contains a list with all the public members in the [GitHub](https://github.com/github) organization.
 It contains minimal information which is needed and used when the public API request rate limit exceeds.
 
-This file can be updated automatically using the [`build.js`](/build.js) script and a [token](https://github.com/settings/tokens):
+This file is updated automatically using the [`build.js`](/build.js) script and a [token](https://github.com/settings/tokens):
 
 ```sh
 $ npm i

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 ## Hubber Memory Game
 
-A simple CSS/HTML/JavaScript matching game
+The classic memory game, with your favorite hubbers
 
-![screen shot 2014-10-10 at 2 58 52 pm](https://cloud.githubusercontent.com/assets/2623954/4599625/c2f53220-50c8-11e4-9b34-390065cfab00.png)
+![](http://i.imgur.com/KLl5oEO.jpg)
 
 ## Resources
 
 Tutorial using [HTML5 Games development by Example: Beginners Guide](http://www.amazon.com/gp/product/B005KRUHXI/ref=kinw_myk_ro_title#).
 
-Hosted using [GitHub Pages.](https://pages.github.com/)
+Hosted using [GitHub Pages](https://pages.github.com/).
 
 ## Contributing
 
@@ -21,6 +21,14 @@ Hosted using [GitHub Pages.](https://pages.github.com/)
 
 Just open the index.html file in a browser. No frameworks needed. :grin:
 
-## TODO
+### Rebuilding the GitHubbers list
 
-- [ ] Figure out how to use the GitHub API to automatically pull in new GitHub staff members
+The [`js/Hubbers.js`](/js/Hubbers.js) file contains a list with all the public members in the [GitHub](https://github.com/github) organization.
+It contains minimal information which is needed and used when the public API request rate limit exceeds.
+
+This file can be updated automatically using the [`build.js`](/build.js) script and a [token](https://github.com/settings/tokens):
+
+```sh
+$ npm i
+$ node build.js <token>
+```

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
         <link rel="icon" type="image/ico" href="favicon.ico"/>
         <meta charset="utf-8">
         <title>Hubber Matching Game</title>
-        <link href='http://fonts.googleapis.com/css?family=Sansita+One' rel='stylesheet' type='text/css'>
-        <link href="http://fonts.googleapis.com/css?family=Orbitron:400,700" rel="stylesheet" type="text/css" >
+        <link href='https://fonts.googleapis.com/css?family=Sansita+One' rel='stylesheet' type='text/css'>
+        <link href="https://fonts.googleapis.com/css?family=Orbitron:400,700" rel="stylesheet" type="text/css" >
         <link rel="stylesheet" href="styles/main.css" />
     </head>
         <body>
@@ -59,7 +59,7 @@
                     </div>
                 </div>
             </section>
-            <script src="http://code.jquery.com/jquery-1.7.2.min.js"></script>
+            <script src="https://code.jquery.com/jquery-1.7.2.min.js"></script>
             <script src="js/gh.min.js"></script>
             <script src="js/Hubbers.js"></script>
             <script src="js/memory-matching.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "hubber-memory-game",
+  "version": "1.0.0",
+  "description": "The classic memory game, with your favorite hubbers",
+  "main": "build.js",
+  "dependencies": {
+    "bug-killer": "^4.0.0",
+    "same-time": "^2.0.0",
+    "gh.js": "^2.2.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/alysonla/hubber-memory-game.git"
+  },
+  "keywords": [
+    "hubbers",
+    "github",
+    "memory",
+    "game"
+  ],
+  "author": "Alyson La <alyson@github.com>",
+  "bugs": {
+    "url": "https://github.com/alysonla/hubber-memory-game/issues"
+  },
+  "homepage": "https://github.com/alysonla/hubber-memory-game#readme"
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
     "game"
   ],
   "author": "Alyson La <alyson@github.com>",
+  "contributors": [
+    "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
+    "Alex Rodas (http://alexrodas.com/)",
+    "Joel Glovier (http://joelglovier.com/)"
+  ],
   "bugs": {
     "url": "https://github.com/alysonla/hubber-memory-game/issues"
   },


### PR DESCRIPTION
- Removed the TODOs section since they were fixed in #8. :tada: 
- Updated the screenshot with an actual state of the project (btw, there are two of my favorite GitHubbers: @defunkt and @pengwynn–best in the GitHub API things). :grin: 
- Added the `package.json`, as mentioned [here](https://github.com/alysonla/hubber-memory-game/pull/8#discussion_r41088689).
- Replaced `http` with `https` so the game can be now loaded over `https`. :lock: 
- Other fixes in README.md (description, how to use the build script etc).
